### PR TITLE
fix: use same import path to stop double loading

### DIFF
--- a/packages/core/src/instance.ts
+++ b/packages/core/src/instance.ts
@@ -1,6 +1,7 @@
 import type { CoreContext } from './context'
 
-import { useConfig } from '../../common/src/node'
+import { useConfig } from '@tg-search/common/node'
+
 import { createCoreContext } from './context'
 import { afterConnectedEventHandler, authEventHandler, useEventHandler } from './event-handler'
 

--- a/packages/core/src/services/config.ts
+++ b/packages/core/src/services/config.ts
@@ -3,9 +3,8 @@ import type { Config } from '@tg-search/common'
 import type { CoreContext } from '../context'
 
 import { configSchema } from '@tg-search/common'
+import { updateConfig as updateConfigToFile, useConfig } from '@tg-search/common/node'
 import { safeParse } from 'valibot'
-
-import { updateConfig as updateConfigToFile, useConfig } from '../../../common/src/node'
 
 export interface ConfigEventToCore {
   'config:fetch': () => void

--- a/packages/core/src/services/session.ts
+++ b/packages/core/src/services/session.ts
@@ -4,12 +4,11 @@ import type { CoreContext } from '../context'
 
 import { access, mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
 
+import { getSessionPath, useConfig } from '@tg-search/common/node'
 import { useLogger } from '@unbird/logg'
 import { Err, Ok } from '@unbird/result'
 import path from 'pathe'
 import { StringSession } from 'telegram/sessions'
-
-import { getSessionPath, useConfig } from '../../../common/src/node'
 
 export interface SessionEventToCore {
   'session:update': (data: { phoneNumber: string, session: string }) => void


### PR DESCRIPTION
运行之后，执行到 `packages/common/src/node/config.ts` 下的 `useConfig` 方法会报错：`Config not initialized`

模块被加载了两次

应该是 #325 中修改了 `package.json` 修改了 `core` 模块的导出模式后出现的