### PR TITLE
chore(sync): sync page i18n

### DIFF
--- a/apps/web/src/components/VirtualMessageList.vue
+++ b/apps/web/src/components/VirtualMessageList.vue
@@ -181,9 +181,9 @@ defineExpose({
     <!-- Loading indicators -->
     <div
       v-if="isScrolling"
-      class="absolute right-4 top-4 border rounded-full bg-card/90 px-3 py-1.5 text-xs text-muted-foreground font-medium shadow-lg backdrop-blur-sm"
+      class="absolute left-1/2 top-4 z-20 flex items-center gap-1.5 border rounded-full bg-card/90 px-3 py-1.5 text-xs text-muted-foreground font-medium leading-none shadow-lg backdrop-blur-sm -translate-x-1/2"
     >
-      <span class="i-lucide-loader-2 mr-1.5 inline-block animate-spin" />
+      <span class="i-lucide-loader-2 inline-block h-3 w-3 animate-spin" />
       {{ t('virtualMessageList.scrolling') }}
     </div>
 

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -120,7 +120,12 @@
     "syncCompleted": "Sync completed",
     "syncFailed": "Sync failed",
     "syncPrompt": "After a synchronized conversation, you can search all chat records.",
-    "syncing": "Syncing..."
+    "syncing": "Syncing...",
+    "initTakeoutSession": "Init takeout session",
+    "getMessages": "Get messages",
+    "startingIncrementalSync": "Starting incremental sync",
+    "incrementalSyncCompleted": "Incremental sync completed",
+    "processedMessages": "Processed {processed}/{total} messages"
   },
   "virtualMessageList": {
     "scrolling": "Scrolling..."

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -120,10 +120,15 @@
     "syncCompleted": "同步完成",
     "syncFailed": "同步失败",
     "syncPrompt": "同步对话之后才能搜索全部的聊天记录",
-    "syncing": "同步中..."
+    "syncing": "同步中...",
+    "initTakeoutSession": "初始化数据导出会话",
+    "getMessages": "获取消息",
+    "startingIncrementalSync": "开始增量同步",
+    "incrementalSyncCompleted": "增量同步完成",
+    "processedMessages": "已处理 {processed}/{total} 条消息"
   },
   "virtualMessageList": {
-    "scrolling": "滚动中..."
+    "scrolling": "加载中"
   },
   "errors": {
     "floodWait": "请求过于频繁，请等待 {seconds} 秒后再试。",


### PR DESCRIPTION
修复在同步框内使用中文时，还显示英文的问题。增加中英文同步时的状态显示。
<img width="1692" height="378" alt="image" src="https://github.com/user-attachments/assets/a261faeb-029c-4130-a2c4-1b45934a0288" />

修复浏览消息时弹出的“滚动中”的翻译问题，并将其位置居中，也同时修复了其中旋转圆形不居中的问题。
<img width="300" height="158" alt="image" src="https://github.com/user-attachments/assets/fbfd9d02-77b8-4c9f-bf05-99d1f5a35991" />
