### PR TITLE
fix(message): strip server-only fields from messages to reduce WebSocket payload size

### DIFF
--- a/apps/server/src/ws-events.ts
+++ b/apps/server/src/ws-events.ts
@@ -36,26 +36,29 @@ export function sendWsEvent<T extends keyof WsEventToClient>(
   event: T,
   data: WsEventToClientData<T>,
 ) {
-  peer.send(createWsMessage(event, data))
+  const message = createWsMessage(event, data)
+  if (message !== null) {
+    peer.send(message)
+  }
 }
 
 export function createWsMessage<T extends keyof WsEventToClient>(
   type: T,
   data: WsEventToClientData<T>,
-): Extract<WsMessageToClient, { type: T }> {
+): Extract<WsMessageToClient, { type: T }> | null {
   try {
     // ensure args[0] can be stringified
     const stringifiedData = JSON.stringify(data)
     if (stringifiedData.length > 1024 * 1024) {
-      useLogger().withFields({ type, length: stringifiedData.length }).warn('Dropped event data')
-      return { type, data: undefined } as Extract<WsMessageToClient, { type: T }>
+      useLogger().withFields({ type, length: stringifiedData.length }).warn('Dropped event data: payload too large')
+      return null
     }
 
     return { type, data } as Extract<WsMessageToClient, { type: T }>
   }
   catch {
-    useLogger().withFields({ type }).warn('Dropped event data')
+    useLogger().withFields({ type }).warn('Dropped event data: serialization failed')
 
-    return { type, data: undefined } as Extract<WsMessageToClient, { type: T }>
+    return null
   }
 }

--- a/packages/core/src/event-handlers/storage.ts
+++ b/packages/core/src/event-handlers/storage.ts
@@ -15,6 +15,7 @@ import {
   recordChats,
   recordMessagesWithMedia,
   retrieveMessages,
+  stripServerOnlyFieldsFromMessages,
 } from '../models'
 import { embedContents } from '../utils/embed'
 
@@ -41,7 +42,7 @@ export function registerStorageEventHandlers(ctx: CoreContext) {
     }
 
     const messages = (await fetchMessagesWithPhotos(accountId, chatId, pagination)).unwrap()
-    emitter.emit('storage:messages', { messages })
+    emitter.emit('storage:messages', { messages: stripServerOnlyFieldsFromMessages(messages) })
   })
 
   emitter.on('storage:fetch:message-context', async ({ chatId, messageId, before = 20, after = 20 }) => {
@@ -63,7 +64,7 @@ export function registerStorageEventHandlers(ctx: CoreContext) {
       { chatId, messageId, before: safeBefore, after: safeAfter },
     )).unwrap()
 
-    emitter.emit('storage:messages:context', { chatId, messageId, messages })
+    emitter.emit('storage:messages:context', { chatId, messageId, messages: stripServerOnlyFieldsFromMessages(messages) })
 
     // After emitting the initial messages, identify messages that might be missing media
     // and trigger a fetch from Telegram to download them
@@ -190,6 +191,6 @@ export function registerStorageEventHandlers(ctx: CoreContext) {
 
     const coreMessages = convertToCoreRetrievalMessages(dbMessages)
 
-    emitter.emit('storage:search:messages:data', { messages: coreMessages })
+    emitter.emit('storage:search:messages:data', { messages: stripServerOnlyFieldsFromMessages(coreMessages) })
   })
 }

--- a/packages/core/src/models/utils/message.ts
+++ b/packages/core/src/models/utils/message.ts
@@ -13,6 +13,25 @@ export interface DBRetrievalMessages extends Omit<DBSelectMessage, 'content_vect
   chat_name?: string | null
 }
 
+/**
+ * Strip large server-only fields (vectors, jiebaTokens) from CoreMessage before sending to client.
+ * These fields are only used for server-side search and can cause WebSocket messages to exceed size limits.
+ */
+export function stripServerOnlyFields<T extends CoreMessage>(message: T): T {
+  return {
+    ...message,
+    vectors: { vector1536: [], vector1024: [], vector768: [] },
+    jiebaTokens: [],
+  }
+}
+
+/**
+ * Strip large server-only fields from an array of CoreMessages.
+ */
+export function stripServerOnlyFieldsFromMessages<T extends CoreMessage>(messages: T[]): T[] {
+  return messages.map(stripServerOnlyFields)
+}
+
 export function convertToCoreMessageFromDB(message: DBSelectMessage): CoreMessage {
   return {
     uuid: message.id,

--- a/packages/core/src/services/message-resolver.ts
+++ b/packages/core/src/services/message-resolver.ts
@@ -6,6 +6,7 @@ import type { SyncOptions } from '../types/events'
 
 import { useLogger } from '@guiiai/logg'
 
+import { stripServerOnlyFields, stripServerOnlyFieldsFromMessages } from '../models/utils/message'
 import { convertToCoreMessage } from '../utils/message'
 
 export type MessageResolverService = ReturnType<ReturnType<typeof createMessageResolverService>>
@@ -30,7 +31,7 @@ export function createMessageResolverService(ctx: CoreContext) {
 
       // Return the messages first
       if (!options.takeout) {
-        emitter.emit('message:data', { messages: coreMessages })
+        emitter.emit('message:data', { messages: stripServerOnlyFieldsFromMessages(coreMessages) })
       }
 
       // Storage the messages first
@@ -57,7 +58,7 @@ export function createMessageResolverService(ctx: CoreContext) {
             else if (resolver.stream) {
               for await (const message of resolver.stream({ messages: coreMessages, syncOptions: options.syncOptions })) {
                 if (!options.takeout) {
-                  emitter.emit('message:data', { messages: [message] })
+                  emitter.emit('message:data', { messages: [stripServerOnlyFields(message)] })
                 }
 
                 emitter.emit('storage:record:messages', { messages: [message] })


### PR DESCRIPTION
This pull request introduces improvements to how messages are sent from the server to the client, focusing on preventing oversized WebSocket payloads and removing server-only fields from message objects. The changes ensure that large, internal-use-only fields are stripped from messages before they are emitted to the client, and that WebSocket events are only sent if the payload is valid and within size limits.

Message sanitization and payload size safety:

* Added `stripServerOnlyFields` and `stripServerOnlyFieldsFromMessages` utility functions in `message.ts` to remove large, server-only fields (`vectors`, `jiebaTokens`) from `CoreMessage` objects before sending them to the client. This prevents oversized payloads and ensures only client-relevant data is transmitted.
* Updated all relevant event emitters in `storage.ts` and `message-resolver.ts` to use these new functions, ensuring that all messages sent to the client are sanitized. [[1]](diffhunk://#diff-75f517abc3099830a6028a029898e6cd270233d88eafc3967aa770fd49453e94L44-R45) [[2]](diffhunk://#diff-75f517abc3099830a6028a029898e6cd270233d88eafc3967aa770fd49453e94L66-R67) [[3]](diffhunk://#diff-75f517abc3099830a6028a029898e6cd270233d88eafc3967aa770fd49453e94L193-R194) [[4]](diffhunk://#diff-e48a7d4224a503eac4dd3aa214cedf1cb43b1488763c0f66ea941578ac0f9450L33-R34) [[5]](diffhunk://#diff-e48a7d4224a503eac4dd3aa214cedf1cb43b1488763c0f66ea941578ac0f9450L60-R61)

WebSocket message handling improvements:

* Modified `createWsMessage` in `ws-events.ts` to return `null` instead of a partial message if serialization fails or payload is too large, and updated `sendWsEvent` to only send non-null messages. This prevents sending malformed or incomplete messages over WebSocket.

These changes collectively improve the reliability and efficiency of server-to-client communication by ensuring only necessary data is sent and by protecting against oversized or invalid WebSocket messages.