### PR TITLE
Add Telegram deep link generation utilities

### DIFF
--- a/apps/web/src/components/messages/MessageBubble.vue
+++ b/apps/web/src/components/messages/MessageBubble.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { CoreMessage } from '@tg-search/core/types'
 
-import { formatMessageTimestamp } from '@tg-search/client'
+import { formatMessageTimestamp, useChatStore } from '@tg-search/client'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 
@@ -9,19 +10,29 @@ import EntityAvatar from '../avatar/EntityAvatar.vue'
 import Button from '../ui/Button/Button.vue'
 import MediaRenderer from './media/MediaRenderer.vue'
 
-defineProps<{
+import { getMessageLink, getUserProfileLink } from '../../utils/telegram-links'
+
+const props = defineProps<{
   message: CoreMessage
 }>()
 
 const { t } = useI18n()
+const chatStore = useChatStore()
+
+const currentChat = computed(() => chatStore.getChat(props.message.chatId))
+
+const messageTelegramLink = computed(() => {
+  if (!currentChat.value)
+    return null
+  return getMessageLink(currentChat.value, props.message.platformMessageId)
+})
+
+const senderProfileLink = computed(() => {
+  return getUserProfileLink(props.message.fromId)
+})
 
 function copyMessageLink(message: CoreMessage) {
   navigator.clipboard.writeText(`https://t.me/c/${message.chatId}/${message.platformMessageId}`)
-  toast.success(t('messages.copied'))
-}
-
-function copyMessageDeepLink(message: CoreMessage) {
-  navigator.clipboard.writeText(`tg://privatepost?channel=${message.chatId}&post=${message.platformMessageId}`)
   toast.success(t('messages.copied'))
 }
 
@@ -29,11 +40,22 @@ function copyMessageText(message: CoreMessage) {
   navigator.clipboard.writeText(message.content)
   toast.success(t('messages.copied'))
 }
+
+function openInTelegram() {
+  const link = messageTelegramLink.value
+  if (link) {
+    window.open(link.tgLink, '_self')
+  }
+}
 </script>
 
 <template>
   <div class="group mx-3 my-1 flex items-start gap-3 rounded-xl p-3 transition-all duration-200 md:mx-4 md:gap-4 hover:bg-accent/50">
-    <div class="shrink-0 pt-0.5">
+    <a
+      class="shrink-0 cursor-pointer pt-0.5"
+      :href="senderProfileLink.tgLink"
+      :title="t('messages.openProfileInTelegram')"
+    >
       <EntityAvatar
         :id="message.fromId"
         entity="other"
@@ -41,7 +63,7 @@ function copyMessageText(message: CoreMessage) {
         :name="message.fromName"
         size="md"
       />
-    </div>
+    </a>
     <div class="min-w-0 flex-1">
       <div class="mb-1.5 flex items-baseline gap-2">
         <span class="truncate text-sm text-foreground font-semibold">{{ message.fromName }}</span>
@@ -52,7 +74,7 @@ function copyMessageText(message: CoreMessage) {
         <MediaRenderer :message="message" />
       </div>
 
-      <!-- Message ID badge (hidden by default, shown on hover) -->
+      <!-- Message ID badge and actions (hidden by default, shown on hover) -->
       <div class="mt-1.5 flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100">
         <span class="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground">
           <span class="i-lucide-hash mr-1 h-3 w-3" />
@@ -71,11 +93,12 @@ function copyMessageText(message: CoreMessage) {
           @click="copyMessageLink(message)"
         />
         <Button
-          v-if="message.fromId.startsWith('-100')"
+          v-if="messageTelegramLink"
           icon="i-lucide-external-link"
           size="sm"
           class="h-3 w-3 shrink-0 px-0 opacity-50 transition-opacity hover:opacity-100"
-          @click="copyMessageDeepLink(message)"
+          :title="t('messages.openInTelegram')"
+          @click="openInTelegram"
         />
       </div>
     </div>

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -113,7 +113,9 @@
   "messages": {
     "copied": "Copied to clipboard",
     "copyMessageLink": "Copy message link",
-    "openInChat": "Open in chat"
+    "openInChat": "Open in chat",
+    "openInTelegram": "Open in Telegram",
+    "openProfileInTelegram": "Open profile in Telegram"
   },
   "search": {
     "noRelatedMessages": "No related messages found",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -113,7 +113,9 @@
   "messages": {
     "copied": "已复制到剪贴板",
     "copyMessageLink": "复制消息链接",
-    "openInChat": "在聊天中打开"
+    "openInChat": "在聊天中打开",
+    "openInTelegram": "在 Telegram 中打开",
+    "openProfileInTelegram": "在 Telegram 中打开资料"
   },
   "search": {
     "noRelatedMessages": "没有找到相关消息",

--- a/apps/web/src/pages/chat/[id].vue
+++ b/apps/web/src/pages/chat/[id].vue
@@ -16,6 +16,7 @@ import SummaryDialog from '../../components/SummaryDialog.vue'
 import VirtualMessageList from '../../components/VirtualMessageList.vue'
 
 import { Button } from '../../components/ui/Button'
+import { getChatProfileLink } from '../../utils/telegram-links'
 
 const { t } = useI18n()
 
@@ -30,6 +31,11 @@ const { activeSessionId } = storeToRefs(useSessionStore())
 
 const { sortedMessageIds, messageWindow, sortedMessageArray } = storeToRefs(messageStore)
 const currentChat = computed<CoreDialog | undefined>(() => chatStore.getChat(id.toString()))
+const chatTelegramLink = computed(() => {
+  if (!currentChat.value)
+    return null
+  return getChatProfileLink(currentChat.value)
+})
 
 const messageLimit = ref(100)
 const messageOffset = ref(0)
@@ -174,6 +180,13 @@ function sendMessage() {
   toast.success(t('chat.messageSent'))
 }
 
+function openChatInTelegram() {
+  const link = chatTelegramLink.value
+  if (link) {
+    window.open(link.tgLink, '_self')
+  }
+}
+
 function resetPagination() {
   messageOffset.value = 0
 }
@@ -272,15 +285,21 @@ watch(
     <!-- Chat Header -->
     <div class="flex items-center justify-between border-b bg-card/50 px-6 py-4 backdrop-blur-sm">
       <div class="flex items-center gap-3">
-        <EntityAvatar
+        <a
           v-if="currentChat && currentChat.id != null"
-          :id="currentChat.id"
-          entity="other"
-          entity-type="chat"
-          :file-id="currentChat?.avatarFileId"
-          :name="currentChat?.name"
-          size="md"
-        />
+          :href="chatTelegramLink?.tgLink"
+          :title="chatTelegramLink ? t('messages.openInTelegram') : undefined"
+          :class="chatTelegramLink ? 'cursor-pointer' : 'cursor-default'"
+        >
+          <EntityAvatar
+            :id="currentChat.id"
+            entity="other"
+            entity-type="chat"
+            :file-id="currentChat?.avatarFileId"
+            :name="currentChat?.name"
+            size="md"
+          />
+        </a>
         <div>
           <h2 class="text-lg font-semibold">
             {{ currentChat?.name }}
@@ -291,6 +310,16 @@ watch(
         </div>
       </div>
       <div class="flex items-center gap-2">
+        <Button
+          v-if="chatTelegramLink"
+          icon="i-lucide-external-link"
+          variant="ghost"
+          size="sm"
+          :title="t('messages.openInTelegram')"
+          @click="openChatInTelegram"
+        >
+          {{ t('messages.openInTelegram') }}
+        </Button>
         <SummaryDialog :chat-id="id.toString()">
           <template #default="{ open }">
             <Button

--- a/apps/web/src/utils/telegram-links.ts
+++ b/apps/web/src/utils/telegram-links.ts
@@ -1,0 +1,96 @@
+/**
+ * Telegram deep link generation utilities for opening content in the Telegram client.
+ *
+ * Supports:
+ * - User profile links via tg://user?id=<userId>
+ * - Public chat links via tg://resolve?domain=<username>
+ * - Message links for public channels: tg://resolve?domain=<username>&post=<messageId>
+ * - Message links for private channels: tg://privatepost?channel=<channelId>&post=<messageId>
+ */
+
+import type { CoreDialog } from '@tg-search/core/types'
+
+export interface TelegramLink {
+  /** tg:// deep link for opening in the native Telegram client */
+  tgLink: string
+  /** https://t.me/ web fallback link */
+  webLink: string
+}
+
+/**
+ * Strip Telegram's marked peer-ID prefixes (-100 for channels, - for groups)
+ * to get the raw numeric entity ID.
+ */
+function stripPeerPrefix(id: string): string {
+  if (id.startsWith('-100'))
+    return id.slice(4)
+  if (id.startsWith('-'))
+    return id.slice(1)
+  return id
+}
+
+/**
+ * Generate a link to open a user's profile in Telegram.
+ */
+export function getUserProfileLink(userId: string): TelegramLink {
+  const rawId = stripPeerPrefix(userId)
+  return {
+    tgLink: `tg://user?id=${rawId}`,
+    webLink: `https://t.me/@id${rawId}`,
+  }
+}
+
+/**
+ * Generate a link to open a chat (channel/group/user) in Telegram.
+ * Returns null for chat types that don't support direct linking (legacy groups).
+ */
+export function getChatProfileLink(chat: Pick<CoreDialog, 'id' | 'type' | 'username'>): TelegramLink | null {
+  if (chat.username) {
+    return {
+      tgLink: `tg://resolve?domain=${chat.username}`,
+      webLink: `https://t.me/${chat.username}`,
+    }
+  }
+
+  if (chat.type === 'user' || chat.type === 'bot') {
+    return getUserProfileLink(chat.id.toString())
+  }
+
+  // Private channels/supergroups without a username can't be directly opened
+  // via deep link without a message ID
+  return null
+}
+
+/**
+ * Generate a link to open a specific message in Telegram.
+ * Returns null for chat types that don't support message deep linking (DMs, legacy groups).
+ */
+export function getMessageLink(chat: Pick<CoreDialog, 'id' | 'type' | 'username'>, messageId: string): TelegramLink | null {
+  // Public channels/supergroups with username
+  if (chat.username && (chat.type === 'channel' || chat.type === 'supergroup')) {
+    return {
+      tgLink: `tg://resolve?domain=${chat.username}&post=${messageId}`,
+      webLink: `https://t.me/${chat.username}/${messageId}`,
+    }
+  }
+
+  // Private channels/supergroups
+  if (chat.type === 'channel' || chat.type === 'supergroup') {
+    const channelId = stripPeerPrefix(chat.id.toString())
+    return {
+      tgLink: `tg://privatepost?channel=${channelId}&post=${messageId}`,
+      webLink: `https://t.me/c/${channelId}/${messageId}`,
+    }
+  }
+
+  // Groups with username (rare but possible for supergroups detected as groups)
+  if (chat.username && chat.type === 'group') {
+    return {
+      tgLink: `tg://resolve?domain=${chat.username}&post=${messageId}`,
+      webLink: `https://t.me/${chat.username}/${messageId}`,
+    }
+  }
+
+  // Legacy groups and DMs don't support message deep linking
+  return null
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive Telegram deep link generation utilities and integrates them throughout the application to enable opening user profiles, chats, and messages directly in the Telegram client.

## Key Changes

- **New utility module** (`telegram-links.ts`): Created a dedicated module for generating Telegram deep links with support for:
  - User profile links via `tg://user?id=<userId>`
  - Public chat links via `tg://resolve?domain=<username>`
  - Message links for public channels using `tg://resolve?domain=<username>&post=<messageId>`
  - Message links for private channels using `tg://privatepost?channel=<channelId>&post=<messageId>`
  - Automatic fallback to `https://t.me/` web links for each deep link type
  - Proper handling of Telegram's peer-ID prefixes (-100 for channels, - for groups)

- **MessageBubble component**: 
  - Converted sender avatar to a clickable link that opens the user's profile in Telegram
  - Replaced the "copy deep link" button with an "open in Telegram" button that uses the native deep link
  - Integrated the new link generation utilities with computed properties

- **Chat page**:
  - Made the chat avatar clickable to open the chat in Telegram (when supported)
  - Added an "Open in Telegram" button in the chat header for direct access
  - Integrated chat profile link generation

- **Localization**: Added new translation keys for "Open in Telegram" and "Open profile in Telegram" in English and Chinese locales

## Implementation Details

- The utility functions return both `tgLink` (deep link) and `webLink` (fallback) for flexibility
- Gracefully handles unsupported chat types (legacy groups, DMs) by returning `null`
- Uses `window.open(link, '_self')` to open deep links in the native Telegram client
- Maintains backward compatibility with existing message link copying functionality

https://claude.ai/code/session_01EmAWvenAi1b4sAPVPjkzuY