### PR TITLE
docs: support dark mode Star History in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,4 +193,17 @@ pnpm run web:dev
 
 ![Alt](https://repobeats.axiom.co/api/embed/69d5ef9f5e72cd7901b32ff71b5f359bc7ca42ea.svg "Repobeats analytics image")
 
-[![Star History Chart](https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date)](https://star-history.com/#groupultra/telegram-search&Date)
+<picture>
+  <source
+    media="(prefers-color-scheme: dark)"
+    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date&theme=dark"
+  />
+  <source
+    media="(prefers-color-scheme: light)"
+    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+  />
+  <img
+    alt="Star History Chart"
+    src="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+  />
+</picture>

--- a/README.md
+++ b/README.md
@@ -193,17 +193,19 @@ pnpm run web:dev
 
 ![Alt](https://repobeats.axiom.co/api/embed/69d5ef9f5e72cd7901b32ff71b5f359bc7ca42ea.svg "Repobeats analytics image")
 
-<picture>
-  <source
-    media="(prefers-color-scheme: dark)"
-    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date&theme=dark"
-  />
-  <source
-    media="(prefers-color-scheme: light)"
-    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
-  />
-  <img
-    alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
-  />
-</picture>
+<a href="https://star-history.com/#groupultra/telegram-search&Date">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+    />
+    <img
+      alt="Star History Chart"
+      src="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+    />
+  </picture>
+</a>

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -203,4 +203,17 @@ pnpm run web:dev
 
 ![Alt](https://repobeats.axiom.co/api/embed/69d5ef9f5e72cd7901b32ff71b5f359bc7ca42ea.svg "Repobeats analytics image")
 
-[![Star History Chart](https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date)](https://star-history.com/#groupultra/telegram-search&Date)
+<picture>
+  <source
+    media="(prefers-color-scheme: dark)"
+    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date&theme=dark"
+  />
+  <source
+    media="(prefers-color-scheme: light)"
+    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+  />
+  <img
+    alt="Star History Chart"
+    src="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+  />
+</picture>

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -203,17 +203,19 @@ pnpm run web:dev
 
 ![Alt](https://repobeats.axiom.co/api/embed/69d5ef9f5e72cd7901b32ff71b5f359bc7ca42ea.svg "Repobeats analytics image")
 
-<picture>
-  <source
-    media="(prefers-color-scheme: dark)"
-    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date&theme=dark"
-  />
-  <source
-    media="(prefers-color-scheme: light)"
-    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
-  />
-  <img
-    alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
-  />
-</picture>
+<a href="https://star-history.com/#groupultra/telegram-search&Date">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+    />
+    <img
+      alt="Star History Chart"
+      src="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+    />
+  </picture>
+</a>

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -189,4 +189,17 @@ pnpm run web:dev
 
 ![Alt](https://repobeats.axiom.co/api/embed/69d5ef9f5e72cd7901b32ff71b5f359bc7ca42ea.svg "Repobeats analytics image")
 
-[![Star History Chart](https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date)](https://star-history.com/#groupultra/telegram-search&Date)
+<picture>
+  <source
+    media="(prefers-color-scheme: dark)"
+    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date&theme=dark"
+  />
+  <source
+    media="(prefers-color-scheme: light)"
+    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+  />
+  <img
+    alt="Star History Chart"
+    src="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+  />
+</picture>

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -189,17 +189,19 @@ pnpm run web:dev
 
 ![Alt](https://repobeats.axiom.co/api/embed/69d5ef9f5e72cd7901b32ff71b5f359bc7ca42ea.svg "Repobeats analytics image")
 
-<picture>
-  <source
-    media="(prefers-color-scheme: dark)"
-    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date&theme=dark"
-  />
-  <source
-    media="(prefers-color-scheme: light)"
-    srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
-  />
-  <img
-    alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
-  />
-</picture>
+<a href="https://star-history.com/#groupultra/telegram-search&Date">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+    />
+    <img
+      alt="Star History Chart"
+      src="https://api.star-history.com/svg?repos=groupultra/telegram-search&type=Date"
+    />
+  </picture>
+</a>


### PR DESCRIPTION
## Summary

- make the README Star History chart respect GitHub's light and dark color schemes
- replace the single static image link with a `<picture>` element and a dark-theme Star History source

## Why

The previous Star History embed only rendered the default light-theme chart, which looked out of place in GitHub dark mode.

## Validation

- visually verified the README diff to ensure only the Star History block changed
- no code checks were run because this is a documentation-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that swaps an embedded image for a theme-aware `<picture>` block; no runtime code or behavior is affected.
> 
> **Overview**
> Updates the Star History embed in `README.md`, `docs/README_EN.md`, and `docs/README_JA.md` to respect GitHub light/dark themes.
> 
> Replaces the single markdown image link with a `<picture>` element that serves a dark-themed Star History SVG when `prefers-color-scheme: dark` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b66623b2f7f1ad720cbd659a02d80fc5ca50446c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
