### PR TITLE
fix(core): omit Node export from browser runtime

### DIFF
--- a/packages/core/src/application/runtime.test.ts
+++ b/packages/core/src/application/runtime.test.ts
@@ -283,4 +283,25 @@ describe('telegram application runtime remote boundaries', () => {
       [expect.objectContaining({ jiebaTokens: expect.arrayContaining(['中文', '搜索']) })],
     )
   })
+
+  // Regression: static export.ts import pulled node:crypto into Vite browser boot.
+  it('omits exportLocal in browser runtimes', () => {
+    const originalWindow = (globalThis as { window?: unknown }).window
+    ;(globalThis as { window?: unknown }).window = {}
+    try {
+      const runtime = createTelegramApplicationRuntime(createHarness())
+      expect(runtime.exportLocal).toBeUndefined()
+    }
+    finally {
+      if (originalWindow === undefined)
+        delete (globalThis as { window?: unknown }).window
+      else
+        (globalThis as { window?: unknown }).window = originalWindow
+    }
+  })
+
+  it('exposes exportLocal in Node runtimes', () => {
+    const runtime = createTelegramApplicationRuntime(createHarness())
+    expect(runtime.exportLocal).toEqual(expect.any(Function))
+  })
 })

--- a/packages/core/src/application/runtime.ts
+++ b/packages/core/src/application/runtime.ts
@@ -28,13 +28,13 @@ import type { TakeoutService } from '../services/takeout'
 import type { CoreDialog } from '../types/dialog'
 
 import { useLogger } from '@guiiai/logg'
+import { isBrowser } from '@tg-search/common'
 import { Api } from 'telegram'
 import { v4 as uuidv4 } from 'uuid'
 
 import { createJiebaResolver } from '../message-resolvers/jieba-resolver'
 import { models as defaultModels } from '../models'
 import { createEntityService } from '../services/entity'
-import { createExportService } from '../services/export'
 import { createLocalMessagesService } from '../services/local-messages'
 import { createRemoteMessagesService } from '../services/remote-messages'
 import { createStatsAccumulator } from '../services/stats'
@@ -57,7 +57,7 @@ export interface TelegramApplication {
   searchLocalMessages: (input: SearchMessagesInput) => Promise<AppResult<CursorPage<SearchMessageRecord>>>
   getLocalMessageContext: (input: MessageContextInput) => Promise<AppResult<MessageContext>>
   getLocalStats: (input: StatsInput) => Promise<AppResult<StatsResult>>
-  exportLocal: (input: ExportInput, signal?: AbortSignal) => AsyncGenerator<ExportUpdate>
+  exportLocal?: (input: ExportInput, signal?: AbortSignal) => AsyncGenerator<ExportUpdate>
   sync: (input: SyncInput, signal?: AbortSignal) => AsyncGenerator<SyncUpdate>
 }
 
@@ -295,6 +295,19 @@ export function createTelegramApplicationRuntime(options: {
     yield { type: 'completed', taskId, processed }
   }
 
+  // NOTICE: Lazy-import export.ts so Vite's browser bundle never evaluates its node:crypto/fs
+  // deps. Browser runtimes omit exportLocal entirely (see TelegramApplication['exportLocal']).
+  async function* exportLocal(input: ExportInput, signal?: AbortSignal): AsyncGenerator<ExportUpdate> {
+    const { createExportService } = await import('../services/export')
+    yield* createExportService(cursor => localMessages.queryForExport({
+      chatIds: input.chatIds,
+      from: input.from,
+      to: input.to,
+      cursor,
+      limit: 1000,
+    }))(input, signal)
+  }
+
   return {
     listChats: input => appResult(async () => {
       const offset = Number.parseInt(input.cursor ?? '0', 10) || 0
@@ -310,13 +323,7 @@ export function createTelegramApplicationRuntime(options: {
     searchLocalMessages: input => appResult(() => localMessages.search(input)),
     getLocalMessageContext: input => appResult(() => localMessages.context(input)),
     getLocalStats: input => appResult(() => calculateLocalStats(input)),
-    exportLocal: (input, signal) => createExportService(cursor => localMessages.queryForExport({
-      chatIds: input.chatIds,
-      from: input.from,
-      to: input.to,
-      cursor,
-      limit: 1000,
-    }))(input, signal),
+    exportLocal: isBrowser() ? undefined : exportLocal,
     sync,
     dispose: async () => {},
   }

--- a/packages/core/src/handlers/export.ts
+++ b/packages/core/src/handlers/export.ts
@@ -9,7 +9,11 @@ import { safeParse } from 'valibot'
 
 import { invalidArgument } from '../application/errors'
 
-export function registerExportHandler(context: EventContext<any, any>, application: TelegramApplication) {
+type ExportApplication = TelegramApplication & {
+  exportLocal: NonNullable<TelegramApplication['exportLocal']>
+}
+
+export function registerExportHandler(context: EventContext<any, any>, application: ExportApplication) {
   defineStreamInvokeHandler(context, exportContracts.run, async function* (input, options) {
     const parsed = safeParse(exportInputSchema, input)
     if (!parsed.success) {

--- a/packages/core/src/handlers/handlers.test.ts
+++ b/packages/core/src/handlers/handlers.test.ts
@@ -1,12 +1,12 @@
 import type { TelegramApplication } from '../application/runtime'
 
-import { createContext, defineInvokes } from '@moeru/eventa'
-import { chatContracts } from '@tg-search/protocol'
+import { createContext, defineInvokes, defineStreamInvoke } from '@moeru/eventa'
+import { chatContracts, exportContracts } from '@tg-search/protocol'
 import { describe, expect, it, vi } from 'vitest'
 
 import { registerApplicationHandlers } from './index'
 
-function fakeApplication(): TelegramApplication {
+function fakeApplication(overrides: Partial<TelegramApplication> = {}): TelegramApplication {
   return {
     listChats: vi.fn(async () => ({ ok: true as const, data: { items: [], nextCursor: null } })),
     listRemoteMessages: vi.fn(),
@@ -16,6 +16,7 @@ function fakeApplication(): TelegramApplication {
     getLocalStats: vi.fn(),
     exportLocal: vi.fn(),
     sync: vi.fn(),
+    ...overrides,
   }
 }
 
@@ -41,5 +42,28 @@ describe('application invoke handlers', () => {
 
     expect(result).toMatchObject({ ok: false, error: { code: 'INVALID_ARGUMENT' } })
     expect(application.listChats).not.toHaveBeenCalled()
+  })
+
+  // Regression: browser runtimes omit exportLocal (see application/runtime.ts) to avoid
+  // evaluating node:crypto/fs; the handler must not register when it is absent.
+  it('does not register export handler when exportLocal is absent', async () => {
+    const context = createContext()
+    registerApplicationHandlers(context, fakeApplication({ exportLocal: undefined }))
+    const reader = defineStreamInvoke(context, exportContracts.run)({
+      outputDir: 'exports-fixture',
+      format: 'jsonl',
+      timeZone: 'UTC',
+    }).getReader()
+
+    // Unregistered Eventa streams stay pending instead of failing fast.
+    const outcome = await Promise.race([
+      reader.read().then(value => ({ kind: 'read' as const, value })),
+      new Promise<{ kind: 'idle' }>((resolve) => {
+        setTimeout(() => resolve({ kind: 'idle' }), 50)
+      }),
+    ])
+
+    expect(outcome.kind).toBe('idle')
+    await reader.cancel()
   })
 })

--- a/packages/core/src/handlers/index.ts
+++ b/packages/core/src/handlers/index.ts
@@ -13,7 +13,14 @@ export function registerApplicationHandlers(context: EventContext<any, any>, app
   const messageDisposers = registerMessageHandlers(context, application)
   const disposeStats = registerStatsHandler(context, application)
   registerSyncHandler(context, application)
-  registerExportHandler(context, application)
+  // NOTICE: exportLocal is absent in browser runtimes (see application/runtime.ts), so its
+  // presence alone determines whether the Node-only export handler should be registered.
+  if (application.exportLocal) {
+    registerExportHandler(context, {
+      ...application,
+      exportLocal: application.exportLocal,
+    })
+  }
   return () => {
     disposeStats()
     for (const dispose of [...Object.values(chatDisposers), ...Object.values(messageDisposers)]) {


### PR DESCRIPTION
## Summary
- Isolate Node-only JSONL export (`services/export.ts` → `node:crypto`/`fs`) from the Vite browser boot path introduced by #646, which left `web:dev` stuck on the splash screen.
- Make `exportLocal` optional: omit it when `isBrowser()`, lazy-import the export service on Node, and register the Eventa export handler only when `exportLocal` is present.
- Add regression tests for browser omit / Node expose and for unregistered export streams when the handler is skipped.

## Test plan
- [x] `pnpm -F @tg-search/core exec vitest run src/application/runtime.test.ts src/handlers/`
- [x] `pnpm -F @tg-search/core typecheck`
- [x] `pnpm run lint:fix`
- [x] Manual: `pnpm run dev` (`VITE_WITH_CORE=true`) → login page mounts (splash clears)
- [x] Manual (logged in): Sync UI has no JSONL export entry; `services/export.ts` / `node:crypto` not loaded at boot; forced import of `services/export.ts` still fails with Vite `node:path` externalization (proves isolation)


Made with [Cursor](https://cursor.com)