### PR TITLE
fix(web): scan login styles.ts for UnoCSS utilities

### DIFF
--- a/apps/web/src/pages/login/styles.ts
+++ b/apps/web/src/pages/login/styles.ts
@@ -1,3 +1,4 @@
+// @unocss-include
 export const LOGIN_TRANSITION_ENTER_ACTIVE_CLASS = 'transition duration-500 cubic-bezier(0.16, 1, 0.3, 1) absolute inset-0'
 export const LOGIN_TRANSITION_ENTER_FROM_CLASS = 'opacity-0 translate-x-8 scale-95'
 export const LOGIN_TRANSITION_ENTER_TO_CLASS = 'opacity-100 translate-x-0 scale-100'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1862,20 +1862,11 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@floating-ui/core@1.7.3':
-    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
-
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
 
-  '@floating-ui/dom@1.7.4':
-    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
-
   '@floating-ui/dom@1.8.0':
     resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
-
-  '@floating-ui/utils@0.2.10':
-    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
@@ -7147,9 +7138,11 @@ packages:
 
   telegram@2.26.21:
     resolution: {integrity: sha512-I8Lit2CdZe5tHzJbBTiDvRAa1A9iYzXljwDGBspY2XgR0VAWzQwmm49a3n8Kxl7T/2rYOwACRwGXuUwUQmEzVA==}
+    deprecated: This package is archived and no longer maintained. Development continues in teleproto (https://npmjs.com/package/teleproto), a largely compatible, actively maintained fork. See the migration guide at https://docs.teleproto.dev/migrating-from-gramjs
 
   telegram@2.26.22:
     resolution: {integrity: sha512-EIj7Yrjiu0Yosa3FZ/7EyPg9s6UiTi/zDQrFmR/2Mg7pIUU+XjAit1n1u9OU9h2oRnRM5M+67/fxzQluZpaJJg==}
+    deprecated: This package is archived and no longer maintained. Development continues in teleproto (https://npmjs.com/package/teleproto), a largely compatible, actively maintained fork. See the migration guide at https://docs.teleproto.dev/migrating-from-gramjs
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -9333,32 +9326,21 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@floating-ui/core@1.7.3':
-    dependencies:
-      '@floating-ui/utils': 0.2.10
-
   '@floating-ui/core@1.8.0':
     dependencies:
       '@floating-ui/utils': 0.2.12
-
-  '@floating-ui/dom@1.7.4':
-    dependencies:
-      '@floating-ui/core': 1.7.3
-      '@floating-ui/utils': 0.2.10
 
   '@floating-ui/dom@1.8.0':
     dependencies:
       '@floating-ui/core': 1.8.0
       '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/utils@0.2.10': {}
-
   '@floating-ui/utils@0.2.12': {}
 
   '@floating-ui/vue@1.1.9(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@floating-ui/dom': 1.7.4
-      '@floating-ui/utils': 0.2.10
+      '@floating-ui/dom': 1.8.0
+      '@floating-ui/utils': 0.2.12
       vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -14766,7 +14748,7 @@ snapshots:
 
   reka-ui@2.10.1(vue@3.5.39(typescript@5.9.3)):
     dependencies:
-      '@floating-ui/dom': 1.7.4
+      '@floating-ui/dom': 1.8.0
       '@floating-ui/vue': 1.1.9(vue@3.5.39(typescript@5.9.3))
       '@internationalized/date': 3.12.2
       '@internationalized/number': 3.6.5


### PR DESCRIPTION
## Summary
- UnoCSS does not scan plain `.ts` by default, so utilities that only lived in `apps/web/src/pages/login/styles.ts` never made it into the CSS bundle
- Production build A/B check: removing extraction dropped ~3.8KB of CSS and omitted 19 login-only utilities (e.g. `from-foreground`, `bg-clip-text`, `to-foreground/70`, `disabled:bg-primary/40`, `focus:ring-primary/20`, `translate-x-8`, `pl-10`)
- Visible symptom: login title used `text-transparent` without the gradient/`bg-clip-text` rules, so it showed the page background (looked inverted across themes)
- Same root cause also left other login-only styles (disabled buttons, focus rings, step transitions) ungenerated unless they happened to appear in `.vue` files
- Add `// @unocss-include` so all shared login class constants are extracted

## Test plan
- [x] Open `/login` in light and dark mode — title is legible with gradient clip (not page-background-colored)
  - Light: `background-clip: text`, gradient `rgb(9,9,11) → rgba(9,9,11,0.7)`
  - Dark: gradient `rgb(250,250,250) → rgba(250,250,250,0.7)`
- [x] Confirm login primary button hover/active/disabled styles apply
  - Forced `:disabled`: `disabled:bg-primary/40`, `disabled:text-primary-foreground/75`, `disabled:shadow-none`, `disabled:opacity-100` all apply
- [x] Confirm phone input focus ring styles apply
  - Forced `:focus`: `focus:ring-4` (`--un-ring-width: 4px`), `focus:ring-primary/10`, `focus:border-primary/50`, `focus:bg-background`
- [x] `pnpm -F @tg-search/web build` — `dist` CSS contains `bg-clip-text`, `from-foreground`, `to-foreground/70`, `disabled:bg-primary/40`, `focus:ring-4`, `focus:ring-primary/20`, `translate-x-8`, `pl-10`, `active:scale-[0.98]`, `hover:scale-[1.02]` (all PASS)