### PR TITLE
fix(web): escape HTML in highlightKeyword to prevent stored XSS

### DIFF
--- a/apps/web/src/components/messages/MessageList.vue
+++ b/apps/web/src/components/messages/MessageList.vue
@@ -29,7 +29,7 @@ const { copy } = useClipboard()
 
 function escapeHtml(s: string) {
   return s.replace(/[&<>"']/g, c =>
-    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' } as Record<string, string>)[c])
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', '\'': '&#39;' } as Record<string, string>)[c])
 }
 
 function highlightKeyword(text: string, keyword: string) {

--- a/apps/web/src/components/messages/MessageList.vue
+++ b/apps/web/src/components/messages/MessageList.vue
@@ -27,11 +27,18 @@ const hoveredMessage = ref<CoreMessage | null>(null)
 const listRef = ref<HTMLElement | null>(null)
 const { copy } = useClipboard()
 
+function escapeHtml(s: string) {
+  return s.replace(/[&<>"']/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' } as Record<string, string>)[c])
+}
+
 function highlightKeyword(text: string, keyword: string) {
+  const safe = escapeHtml(text)
   if (!keyword)
-    return text
-  const regex = new RegExp(`(${keyword})`, 'gi')
-  return text.replace(regex, '<span class="bg-yellow-200 dark:bg-yellow-800">$1</span>')
+    return safe
+  const escaped = escapeHtml(keyword).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const regex = new RegExp(`(${escaped})`, 'gi')
+  return safe.replace(regex, '<span class="bg-yellow-200 dark:bg-yellow-800">$1</span>')
 }
 
 function copyMessageLink(message: CoreMessage) {


### PR DESCRIPTION
MessageList.vue renders message content via v-html through highlightKeyword(), which did not escape HTML entities. A crafted message containing <img onerror="..."> executes arbitrary JS when rendered in search results.

Escape user content before inserting highlight spans, and escape the keyword to prevent regex injection.
fix #653 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to sanitization before existing `v-html` usage; reduces security risk with no API or data-model changes.
> 
> **Overview**
> **Fixes stored XSS** in message search/list rendering where `highlightKeyword()` output is bound with `v-html`.
> 
> Adds `escapeHtml()` and runs **message body text** through it before wrapping keyword matches in highlight `<span>` tags, so malicious markup in stored messages (e.g. `<img onerror="...">`) is shown as text instead of executing. The **search keyword** is also HTML-escaped and regex-escaped before building the `RegExp`, so special characters in the query cannot break or abuse the pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97c140765afd57f56471fcc1e8f2e4c06f9ec39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->