### PR TITLE
fix(client): preserve DB-derived messageCount when merging Telegram dialog lists

### DIFF
--- a/apps/web/src/pages/sync.vue
+++ b/apps/web/src/pages/sync.vue
@@ -113,6 +113,8 @@ const activeChatId = ref<number | null>(null)
 const runChatIds = ref<number[]>([])
 // Accumulated processed messages from completed chats in the current run.
 const runCompletedMessages = ref(0)
+// Mode snapshot for the current run; `increase` itself is mutated on completion toasts.
+const runIsIncremental = ref(true)
 
 // Sync options dialog state
 const isSyncOptionsDialogOpen = ref(false)
@@ -178,8 +180,9 @@ if (increase.value === undefined || increase.value === null) {
 
 // Automatically switch active visualization to the currently syncing chat
 watch(currentTask, (task, previousTask) => {
-  // Roll up completed scope from the previous task into this run's aggregate stats.
-  if (previousTask && task && previousTask.taskId !== task.taskId && previousTask.progress >= 100) {
+  // Roll up the previous task's scope when the run moves to the next chat.
+  // Full sync never reports exactly 100, so any non-errored task switch counts.
+  if (previousTask && task && previousTask.taskId !== task.taskId && !previousTask.lastError) {
     const completedChatId = Number(previousTask.metadata.chatIds[0])
     const fallbackTotal = chats.value.find(chat => chat.id === completedChatId)?.messageCount ?? 0
     runCompletedMessages.value += previousTask.metadata.totalMessages ?? fallbackTotal
@@ -393,7 +396,7 @@ const liveSyncedCount = computed(() => {
   if (!shouldShowTaskStatus.value) {
     return selectedSyncedMessages.value
   }
-  if (increase.value === false) {
+  if (!runIsIncremental.value) {
     return aggregateProcessedMessages.value
   }
   return Math.max(selectedSyncedMessages.value, aggregateProcessedMessages.value)
@@ -495,6 +498,7 @@ watch([isDesktop, hasMobileStatusContent, isTaskInProgress], ([desktop, hasConte
 
 function handleSync() {
   increase.value = true
+  runIsIncremental.value = true
   runChatIds.value = [...selectedChats.value]
   runCompletedMessages.value = 0
   bridge.sendEvent(CoreEventType.TakeoutRun, {
@@ -508,6 +512,7 @@ function handleSync() {
 
 function handleResync() {
   increase.value = false
+  runIsIncremental.value = false
   runChatIds.value = [...selectedChats.value]
   runCompletedMessages.value = 0
   bridge.sendEvent(CoreEventType.TakeoutRun, {

--- a/apps/web/src/pages/sync.vue
+++ b/apps/web/src/pages/sync.vue
@@ -304,14 +304,6 @@ const aggregateProcessedMessages = computed(() => {
   return Math.min(total, runCompletedMessages.value + currentProcessed)
 })
 
-const aggregateProgress = computed(() => {
-  const total = selectedTotalMessages.value
-  if (total <= 0) {
-    return Math.max(0, Math.min(100, Math.round(currentTaskProgress.value || 0)))
-  }
-  return Math.max(0, Math.min(100, Math.round((aggregateProcessedMessages.value / total) * 100)))
-})
-
 /**
  * Compute disabled state for the "Select All" button.
  * Disabled when a task is in progress or the current scope has no chats.
@@ -370,20 +362,13 @@ function handleSelectAll() {
  * Parses "Processed X/Y messages" and maps known status strings.
  */
 const selectedSyncedMessages = computed(() => {
-  if (selectedChats.value.length === 0) {
+  if (syncScopeChatIds.value.length === 0) {
     return 0
   }
 
-  return selectedChats.value.reduce((sum, chatId) => {
+  return syncScopeChatIds.value.reduce((sum, chatId) => {
     return sum + (chatStatsByChatId.value[String(chatId)]?.syncedMessages ?? 0)
   }, 0)
-})
-
-const selectionPreviewProgress = computed(() => {
-  if (selectedTotalMessages.value <= 0) {
-    return 0
-  }
-  return Math.max(0, Math.min(100, Math.round((selectedSyncedMessages.value / selectedTotalMessages.value) * 100)))
 })
 
 const shouldShowSelectionSummary = computed(() => {
@@ -402,7 +387,16 @@ const summarySelectionTitle = computed(() => {
 })
 
 const summaryProgress = computed(() => {
-  return Math.max(0, Math.min(100, Math.round(shouldShowTaskStatus.value ? aggregateProgress.value : selectionPreviewProgress.value)))
+  const total = selectedTotalMessages.value
+  if (total <= 0) {
+    return Math.max(0, Math.min(100, Math.round(currentTaskProgress.value || 0)))
+  }
+  // chatStatsByChatId is updated live by TakeoutMetrics, so synced/total reflects
+  // cumulative progress instead of restarting at 0 for each run
+  const live = shouldShowTaskStatus.value
+    ? Math.max(selectedSyncedMessages.value, aggregateProcessedMessages.value)
+    : selectedSyncedMessages.value
+  return Math.max(0, Math.min(100, Math.round((Math.min(total, live) / total) * 100)))
 })
 
 const summaryHasError = computed(() => {
@@ -414,8 +408,10 @@ const summaryTotalCount = computed(() => {
 })
 
 const summarySyncedCount = computed(() => {
-  const value = shouldShowTaskStatus.value ? aggregateProcessedMessages.value : selectedSyncedMessages.value
-  return Math.max(0, Math.min(summaryTotalCount.value, value))
+  const live = shouldShowTaskStatus.value
+    ? Math.max(selectedSyncedMessages.value, aggregateProcessedMessages.value)
+    : selectedSyncedMessages.value
+  return Math.max(0, Math.min(summaryTotalCount.value, live))
 })
 
 const summaryUnsyncedCount = computed(() => {

--- a/apps/web/src/pages/sync.vue
+++ b/apps/web/src/pages/sync.vue
@@ -386,17 +386,27 @@ const summarySelectionTitle = computed(() => {
   return t('sync.selectedChats', { count: summarySelectedCount.value })
 })
 
+// chatStatsByChatId is updated live by TakeoutMetrics, so synced/total reflects
+// cumulative progress instead of restarting at 0 for each run. Full resync
+// (increase=false) rebuilds coverage, so only the run counter is meaningful there.
+const liveSyncedCount = computed(() => {
+  if (!shouldShowTaskStatus.value) {
+    return selectedSyncedMessages.value
+  }
+  if (increase.value === false) {
+    return aggregateProcessedMessages.value
+  }
+  return Math.max(selectedSyncedMessages.value, aggregateProcessedMessages.value)
+})
+
 const summaryProgress = computed(() => {
   const total = selectedTotalMessages.value
   if (total <= 0) {
-    return Math.max(0, Math.min(100, Math.round(currentTaskProgress.value || 0)))
+    return shouldShowTaskStatus.value
+      ? Math.max(0, Math.min(100, Math.round(currentTaskProgress.value || 0)))
+      : 0
   }
-  // chatStatsByChatId is updated live by TakeoutMetrics, so synced/total reflects
-  // cumulative progress instead of restarting at 0 for each run
-  const live = shouldShowTaskStatus.value
-    ? Math.max(selectedSyncedMessages.value, aggregateProcessedMessages.value)
-    : selectedSyncedMessages.value
-  return Math.max(0, Math.min(100, Math.round((Math.min(total, live) / total) * 100)))
+  return Math.max(0, Math.min(100, Math.round((Math.min(total, liveSyncedCount.value) / total) * 100)))
 })
 
 const summaryHasError = computed(() => {
@@ -408,10 +418,7 @@ const summaryTotalCount = computed(() => {
 })
 
 const summarySyncedCount = computed(() => {
-  const live = shouldShowTaskStatus.value
-    ? Math.max(selectedSyncedMessages.value, aggregateProcessedMessages.value)
-    : selectedSyncedMessages.value
-  return Math.max(0, Math.min(summaryTotalCount.value, live))
+  return Math.max(0, Math.min(summaryTotalCount.value, liveSyncedCount.value))
 })
 
 const summaryUnsyncedCount = computed(() => {

--- a/packages/client/src/stores/useChat.ts
+++ b/packages/client/src/stores/useChat.ts
@@ -129,6 +129,10 @@ export const useChatStore = defineStore('chat', () => {
 
       return {
         ...incomingChat,
+        // Telegram-sourced dialog lists carry no messageCount; keep the DB-derived one
+        ...(incomingChat.messageCount == null && existingChat.messageCount != null
+          ? { messageCount: existingChat.messageCount }
+          : {}),
         ...(shouldReuseSenderName ? { lastMessageFromName: existingChat.lastMessageFromName } : {}),
         ...(options.preserveUnreadCount && existingChat.unreadCount != null
           ? { unreadCount: existingChat.unreadCount }

--- a/packages/core/src/services/takeout.ts
+++ b/packages/core/src/services/takeout.ts
@@ -657,6 +657,10 @@ export function createTakeoutService(
             await processMessageBatch(task, takeoutMessages(chatId, opts), syncOptions, (c) => {
               updateProgress(c, totalCount)
             })
+
+            if (!task.state.abortController.signal.aborted && !task.state.lastError) {
+              task.updateProgress(100, 'Full sync completed')
+            }
           }
           else {
             const needToSyncCount = Math.max(0, totalCount - stats.message_count)


### PR DESCRIPTION
### Bug

After a page refresh (or any reconnect), the sync UI shows **0 synced messages** for every chat, even though the local database still contains all previously synced messages. This makes users believe their sync progress was lost and that incremental sync restarted from scratch.

### Root cause

`CoreDialog.messageCount` is only populated by the DB stats query (`StorageDialogs` event, via `getChatMessagesStats`). However, on every (re)connect the core also fetches a fresh dialog list from the Telegram API and emits `DialogData` — those dialogs carry **no `messageCount`**.

`mergeDialogs()` in `packages/client/src/stores/useChat.ts` replaces each stored chat wholesale with the incoming object, so whichever `DialogData` event arrives last wipes `messageCount` to `undefined` for all chats. The UI then displays 0.

Verified against a live instance: `chat_messages` contained 147k rows and the stats SQL returned correct per-chat counts, while the UI displayed 0 for every chat.

### Fix

In `mergeDialogs()`, keep the existing `messageCount` when the incoming dialog does not provide one (same pattern already used for `unreadCount` and `lastMessageFromName`).

### Second commit: cumulative progress display during sync

While a takeout task is running, the sync summary switched to a run-local processed counter (`aggregateProcessedMessages`), so starting an incremental sync made the displayed synced count drop from e.g. 147k to 0 and count up over the *remaining* messages — looking like a full re-download even though the engine correctly bounds requests with `minId`/`offsetId`.

`chatStatsByChatId` is already updated live by `TakeoutMetrics` (`initialSyncedMessages + processedCount`), so the summary now uses that cumulative value (with the run-local counter as a floor) for both the count and the progress bar. The task's own "Processed X/Y" message still reports per-run progress.

### Steps to reproduce (before fix)

1. Run in browser mode (`VITE_WITH_CORE=true`), log in, sync a chat.
2. Per-chat synced count shows correctly.
3. Refresh the page and wait for reconnect.
4. All per-chat synced counts show 0, although the PGlite DB still has the data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/state merge and progress display fixes; no auth or data-mutation logic beyond preserving an existing field during dialog merge.
> 
> **Overview**
> Fixes sync UI showing **0 synced messages** after reconnect and **dropping cumulative progress** when incremental sync starts.
> 
> **Dialog merge:** When Telegram `DialogData` arrives without `messageCount`, `mergeDialogs()` now keeps the DB-derived count (same pattern as `unreadCount`), so refresh/reconnect no longer wipes per-chat totals.
> 
> **Sync summary during runs:** The selected-chats panel no longer switches to a run-only processed counter that resets the bar. It uses live `chatStatsByChatId` (updated by `TakeoutMetrics`) as the primary synced count for incremental runs, floored by the run aggregate; full resync still uses the run counter only. Progress is derived from `liveSyncedCount` / total. A `runIsIncremental` snapshot is set on sync/resync so completion toasts can reset `increase` without misclassifying the run.
> 
> **Multi-chat rollup:** Completed-chat message rollup on task switch no longer requires `progress >= 100` (full sync rarely hits exactly 100); any non-errored handoff to the next chat counts.
> 
> **Backend:** Full takeout path explicitly sets task progress to 100 with `'Full sync completed'` after a successful batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80ff5b027adab6a07894b3b0a848208a4bd8fa88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->