### PR TITLE
fix(auth): prevent duplicate Telegram login attempts

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -1,0 +1,33 @@
+import { CoreEventType } from '@tg-search/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { respondToReadyLogin } from './app'
+
+const sendWsEvent = vi.hoisted(() => vi.fn())
+
+vi.mock('./events', () => ({ sendWsEvent }))
+
+beforeEach(() => {
+  sendWsEvent.mockClear()
+})
+
+describe('respondToReadyLogin', () => {
+  it('replays account readiness without emitting a new auth login', () => {
+    const peer = {} as never
+    const account = {
+      accountReady: true,
+      ctx: { getCurrentAccountId: () => 'telegram-account-id' },
+    } as never
+
+    expect(respondToReadyLogin(peer, account)).toBe(true)
+    expect(sendWsEvent).toHaveBeenCalledWith(peer, CoreEventType.AccountReady, { accountId: 'telegram-account-id' })
+  })
+
+  it('does not respond until the account is ready', () => {
+    const peer = {} as never
+    const account = { accountReady: false } as never
+
+    expect(respondToReadyLogin(peer, account)).toBe(false)
+    expect(sendWsEvent).not.toHaveBeenCalled()
+  })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -55,6 +55,15 @@ function ensurePeerApplication(account: AccountState, peerId: string, logger: Lo
   state.unregister = registerApplicationHandlers(state.eventa.context, state.runtime)
 }
 
+export function respondToReadyLogin(peer: Peer, account: AccountState): boolean {
+  if (!account.accountReady) {
+    return false
+  }
+
+  sendWsEvent(peer, CoreEventType.AccountReady, { accountId: account.ctx.getCurrentAccountId() })
+  return true
+}
+
 export function registerCoreEventListeners(logger: Logger, account: AccountState, accountId: string, eventName: keyof FromCoreEvent) {
   if (eventName.startsWith('server:')) {
     return
@@ -164,6 +173,12 @@ export function setupWsRoutes(app: H3, config: Config) {
 
         if (event.type === 'server:event:register') {
           registerCoreEventListeners(logger, account, accountId, event.data.event as keyof FromCoreEvent)
+          return
+        }
+
+        // An account-scoped context already has an authorized Telegram client.
+        // Replaying auth:login from another tab must not create and replace it.
+        if (event.type === CoreEventType.AuthLogin && respondToReadyLogin(peer, account)) {
           return
         }
 

--- a/packages/client/src/event-handlers/auth.ts
+++ b/packages/client/src/event-handlers/auth.ts
@@ -2,7 +2,6 @@ import type { ClientRegisterEventHandler } from '.'
 
 import { useLogger } from '@guiiai/logg'
 import { CoreEventType } from '@tg-search/core'
-import { toast } from 'vue-sonner'
 
 import { useAccountStore } from '../stores/useAccount'
 import { useSessionStore } from '../stores/useSession'
@@ -41,6 +40,5 @@ export function registerBasicEventHandlers(
 
   registerEventHandler(CoreEventType.AuthError, () => {
     useAccountStore().auth.isLoading = false
-    toast.error('Login failed')
   })
 }

--- a/packages/client/src/stores/useAccount.ts
+++ b/packages/client/src/stores/useAccount.ts
@@ -25,8 +25,6 @@ export const useAccountStore = defineStore('account', () => {
   const attemptCounter = ref(0)
   const MAX_ATTEMPTS = 3
   let reconnectTimer: number | undefined
-  const AUTH_TIMEOUT_MS = 20000
-  let authTimeoutTimer: number | undefined
 
   // --- Account State ---
   const accountSettings = ref(generateDefaultAccountSettings())
@@ -147,29 +145,6 @@ export const useAccountStore = defineStore('account', () => {
   }
 
   // --- Watchers ---
-  watch(
-    () => authStatus.value.isLoading,
-    (isLoading) => {
-      if (!isLoading) {
-        if (authTimeoutTimer) {
-          window.clearTimeout(authTimeoutTimer)
-          authTimeoutTimer = undefined
-        }
-        return
-      }
-
-      if (authTimeoutTimer)
-        window.clearTimeout(authTimeoutTimer)
-
-      authTimeoutTimer = window.setTimeout(() => {
-        if (!authStatus.value.isLoading)
-          return
-        authStatus.value.isLoading = false
-        toast.error('Login timed out')
-      }, AUTH_TIMEOUT_MS)
-    },
-  )
-
   /**
    * Watch the active session's readiness status and handle reconnection logic.
    */

--- a/packages/core/src/services/connection.test.ts
+++ b/packages/core/src/services/connection.test.ts
@@ -1,0 +1,146 @@
+import { EventEmitter } from 'eventemitter3'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { CoreEventType } from '../types/events'
+import { createConnectionService } from './connection'
+
+const telegramMock = vi.hoisted(() => {
+  const clients: TelegramClient[] = []
+  const nextConnect: Array<() => Promise<boolean>> = []
+  const nextAuthorization: boolean[] = []
+
+  class TelegramClient {
+    connected = false
+    connect: ReturnType<typeof vi.fn>
+    isUserAuthorized: ReturnType<typeof vi.fn>
+    signInUser: ReturnType<typeof vi.fn>
+    destroy: ReturnType<typeof vi.fn>
+    session: { save: ReturnType<typeof vi.fn> }
+
+    constructor() {
+      this.connect = vi.fn(nextConnect.shift() ?? (async () => true))
+      this.isUserAuthorized = vi.fn(async () => nextAuthorization.shift() ?? true)
+      this.signInUser = vi.fn()
+      this.destroy = vi.fn(async () => undefined)
+      this.session = { save: vi.fn(async () => 'saved-session') }
+      clients.push(this)
+    }
+  }
+
+  return { clients, nextAuthorization, nextConnect, TelegramClient }
+})
+
+vi.mock('telegram', () => ({
+  Api: { auth: { LogOut: class {} } },
+  TelegramClient: telegramMock.TelegramClient,
+}))
+
+vi.mock('telegram/network', () => ({ ConnectionTCPObfuscated: class {} }))
+
+vi.mock('telegram/sessions', () => ({
+  StringSession: class {
+    constructor(_session?: string) {}
+  },
+}))
+
+function createContext() {
+  const emitter = new EventEmitter()
+  return {
+    emitter,
+    setClient: vi.fn(),
+    withError: vi.fn((error: unknown) => error instanceof Error ? error : new Error(String(error))),
+  }
+}
+
+const logger = {
+  withContext: vi.fn(),
+  withFields: vi.fn(),
+  verbose: vi.fn(),
+  log: vi.fn(),
+  warn: vi.fn(),
+  withError: vi.fn(),
+}
+logger.withContext.mockReturnValue(logger)
+logger.withFields.mockReturnValue(logger)
+logger.withError.mockReturnValue(logger)
+
+function createService() {
+  const ctx = createContext()
+  const service = createConnectionService(ctx as never, logger as never, { apiId: 1, apiHash: 'hash' })
+  return { ctx, service }
+}
+
+afterEach(() => {
+  telegramMock.clients.length = 0
+  telegramMock.nextAuthorization.length = 0
+  telegramMock.nextConnect.length = 0
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('connection service login lifecycle', () => {
+  it('allows Telegram client retries to complete after the former five-second deadline', async () => {
+    vi.useFakeTimers()
+    const { ctx, service } = createService()
+    telegramMock.nextConnect.push(() => new Promise(resolve => setTimeout(() => resolve(true), 5_100)))
+    const login = service.loginWithSession('session')
+
+    await vi.advanceTimersByTimeAsync(5_100)
+
+    expect((await login).orUndefined()).toBe(telegramMock.clients[0])
+    expect(ctx.setClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys a client when connecting fails', async () => {
+    const { service } = createService()
+    telegramMock.nextConnect.push(async () => {
+      throw new Error('network failed')
+    })
+    const login = service.loginWithSession('session')
+
+    expect((await login).orUndefined()).toBeUndefined()
+    expect(telegramMock.clients[0]!.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('returns an error and destroys a client when connect reports false', async () => {
+    const { service } = createService()
+    telegramMock.nextConnect.push(async () => false)
+
+    const result = await service.loginWithSession('session')
+
+    expect(result.orUndefined()).toBeUndefined()
+    expect(telegramMock.clients[0]!.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('destroys an unauthorized session client', async () => {
+    const { service } = createService()
+    telegramMock.nextAuthorization.push(false)
+    const login = service.loginWithSession('session')
+
+    expect((await login).orUndefined()).toBeUndefined()
+    expect(telegramMock.clients[0]!.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a client retained after AuthConnected handling throws', async () => {
+    const { ctx, service } = createService()
+    ctx.emitter.on(CoreEventType.AuthConnected, () => {
+      throw new Error('bootstrap failed')
+    })
+
+    const result = await service.loginWithSession('session')
+
+    expect(result.orUndefined()).toBeUndefined()
+    expect(ctx.setClient).toHaveBeenCalledWith(telegramMock.clients[0])
+    expect(telegramMock.clients[0]!.destroy).not.toHaveBeenCalled()
+  })
+
+  it('shares one login attempt across session and phone entry points', async () => {
+    const { ctx, service } = createService()
+    const first = service.loginWithSession('session')
+    const second = service.loginWithPhone('+15555550123')
+
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2)
+    expect(telegramMock.clients).toHaveLength(1)
+    expect(ctx.setClient).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/core/src/services/connection.ts
+++ b/packages/core/src/services/connection.ts
@@ -110,89 +110,136 @@ export function createConnectionService(ctx: CoreContext, logger: Logger, option
   }
 
   async function connectOrThrow(client: TelegramClient): Promise<void> {
-    const CONNECT_TIMEOUT = 5000
-
-    const isConnected = await Promise.race<boolean>([
-      client.connect(),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout connecting to Telegram, check your internet connection and try again')), CONNECT_TIMEOUT)),
-    ])
+    // TelegramClient owns connection retries and their delay. Racing it against
+    // an unrelated timeout leaves a live connection attempt behind after the
+    // caller has already treated it as failed.
+    const isConnected = await client.connect()
 
     if (!isConnected) {
       throw new Error('Connected failed, check your internet connection and try again')
     }
   }
 
-  async function loginWithSession(session: StringSession | string): Promise<Result<TelegramClient>> {
+  let loginInFlight: Promise<Result<TelegramClient>> | undefined
+
+  async function destroyCandidate(client: TelegramClient | undefined) {
+    if (!client) {
+      return
+    }
+
     try {
-      const client = (await init(session)).expect('Failed to initialize Telegram client')
-      await connectOrThrow(client)
-
-      const isAuthorized = await client.isUserAuthorized()
-      if (!isAuthorized) {
-        // Surface this as an auth-specific error so the frontend can fall
-        // back to manual login and optionally clear the stored session.
-        ctx.emitter.emit(CoreEventType.AuthError)
-        ctx.emitter.emit(CoreEventType.AuthDisconnected)
-        return Err(ctx.withError('User is not authorized'))
-      }
-
-      // NOTE: The client will return string session, so forward it to frontend
-      const sessionString = String(await client.session.save())
-      logger.withFields({ hasSession: !!sessionString }).verbose('Forwarding session to client')
-
-      // 1) Forward updated session to frontend so it can persist it.
-      ctx.emitter.emit(CoreEventType.SessionUpdate, { session: sessionString })
-
-      // 2) Attach client to context for subsequent services.
-      ctx.setClient(client)
-
-      // 3) Finally signal that auth is connected; this will trigger
-      //    afterConnectedEventHandler, which will establish current
-      //    account ID and bootstrap dialogs/storage.
-      ctx.emitter.emit(CoreEventType.AuthConnected)
-
-      logger.log('Login with session successful')
-
-      return Ok(client)
+      await client.destroy()
     }
     catch (error) {
-      ctx.emitter.emit(CoreEventType.AuthError)
-      return Err(ctx.withError(error, 'Failed to login with session'))
+      logger.withError(error).warn('Failed to destroy unsuccessful Telegram client')
     }
   }
 
-  async function loginWithPhone(phoneNumber: string): Promise<Result<TelegramClient>> {
-    try {
-      const client = (await init()).expect('Failed to initialize Telegram client')
-      await connectOrThrow(client)
+  function runLogin(login: () => Promise<Result<TelegramClient>>): Promise<Result<TelegramClient>> {
+    if (loginInFlight) {
+      logger.verbose('Reusing in-flight Telegram login')
+      return loginInFlight
+    }
 
-      const isAuthorized = await client.isUserAuthorized()
-      if (!isAuthorized) {
-        await signIn(phoneNumber, client)
+    loginInFlight = login().finally(() => {
+      loginInFlight = undefined
+    })
+    return loginInFlight
+  }
+
+  async function loginWithSession(session: StringSession | string): Promise<Result<TelegramClient>> {
+    return runLogin(async () => {
+      let client: TelegramClient | undefined
+      let retained = false
+
+      try {
+        client = (await init(session)).expect('Failed to initialize Telegram client')
+        await connectOrThrow(client)
+
+        const isAuthorized = await client.isUserAuthorized()
+        if (!isAuthorized) {
+          // Surface this as an auth-specific error so the frontend can fall
+          // back to manual login and optionally clear the stored session.
+          ctx.emitter.emit(CoreEventType.AuthError)
+          ctx.emitter.emit(CoreEventType.AuthDisconnected)
+          return Err(ctx.withError('User is not authorized'))
+        }
+
+        // NOTE: The client will return string session, so forward it to frontend
+        const sessionString = String(await client.session.save())
+        logger.withFields({ hasSession: !!sessionString }).verbose('Forwarding session to client')
+
+        // 1) Forward updated session to frontend so it can persist it.
+        ctx.emitter.emit(CoreEventType.SessionUpdate, { session: sessionString })
+
+        // 2) Attach client to context for subsequent services.
+        ctx.setClient(client)
+        retained = true
+
+        // 3) Finally signal that auth is connected; this will trigger
+        //    afterConnectedEventHandler, which will establish current
+        //    account ID and bootstrap dialogs/storage.
+        ctx.emitter.emit(CoreEventType.AuthConnected)
+
+        logger.log('Login with session successful')
+
+        return Ok(client)
       }
+      catch (error) {
+        ctx.emitter.emit(CoreEventType.AuthError)
+        return Err(ctx.withError(error, 'Failed to login with session'))
+      }
+      finally {
+        if (!retained) {
+          await destroyCandidate(client)
+        }
+      }
+    })
+  }
 
-      // NOTE: The client will return string session, so forward it to frontend
-      const sessionString = String(await client.session.save())
-      logger.withFields({ hasSession: !!sessionString }).verbose('Forwarding session to client')
+  async function loginWithPhone(phoneNumber: string): Promise<Result<TelegramClient>> {
+    return runLogin(async () => {
+      let client: TelegramClient | undefined
+      let retained = false
 
-      // 1) Forward updated session
-      ctx.emitter.emit(CoreEventType.SessionUpdate, { session: sessionString })
+      try {
+        client = (await init()).expect('Failed to initialize Telegram client')
+        await connectOrThrow(client)
 
-      // 2) Attach client
-      ctx.setClient(client)
+        const isAuthorized = await client.isUserAuthorized()
+        if (!isAuthorized) {
+          await signIn(phoneNumber, client)
+        }
 
-      // 3) Notify connected; afterConnectedEventHandler will establish
-      //    current account ID and bootstrap dialogs/storage.
-      ctx.emitter.emit(CoreEventType.AuthConnected)
+        // NOTE: The client will return string session, so forward it to frontend
+        const sessionString = String(await client.session.save())
+        logger.withFields({ hasSession: !!sessionString }).verbose('Forwarding session to client')
 
-      logger.log('Login with phone successful')
+        // 1) Forward updated session
+        ctx.emitter.emit(CoreEventType.SessionUpdate, { session: sessionString })
 
-      return Ok(client)
-    }
-    catch (error) {
-      ctx.emitter.emit(CoreEventType.AuthError)
-      return Err(ctx.withError(error, 'Failed to login with phone'))
-    }
+        // 2) Attach client
+        ctx.setClient(client)
+        retained = true
+
+        // 3) Notify connected; afterConnectedEventHandler will establish
+        //    current account ID and bootstrap dialogs/storage.
+        ctx.emitter.emit(CoreEventType.AuthConnected)
+
+        logger.log('Login with phone successful')
+
+        return Ok(client)
+      }
+      catch (error) {
+        ctx.emitter.emit(CoreEventType.AuthError)
+        return Err(ctx.withError(error, 'Failed to login with phone'))
+      }
+      finally {
+        if (!retained) {
+          await destroyCandidate(client)
+        }
+      }
+    })
   }
 
   async function signIn(phoneNumber: string, client: TelegramClient): Promise<Api.TypeUser> {


### PR DESCRIPTION
## Summary

- let TelegramClient own its bounded connection retry lifecycle instead of reporting a false five-second timeout
- share concurrent session and phone login attempts, and destroy every unsuccessful candidate client
- make repeated auth requests idempotent for an already-ready server account
- remove the independent client auth timeout and duplicate generic error toast

## Root cause

The outer five-second `Promise.race` rejected without cancelling `client.connect()`. Telegram retries therefore continued after the UI had already reported failure, while repeated login events could construct additional clients that were not cleaned up.

## Validation

- core connection lifecycle tests: 6 passed
- server ready-login tests: 2 passed
- client account-store tests: 7 passed
- `pnpm run typecheck`: 17 tasks passed
- `pnpm run lint:fix`
- `git diff --check`

The server Vitest run emits the existing Node `--localstorage-file` warning; all tests pass.

Fixes #657